### PR TITLE
Add fast ODE fitting and enhanced fit plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ using a two-stage pipeline: **Direct Kinetics** for fast initial estimates, foll
 
 - **`.cxw` parser** — reads ZIP/XML/HDF5 experiment files directly
 - **Direct Kinetics (DK)** — millisecond-scale linear fit from dR/dt vs R
-- **ODE fitting** — full 1:1 Langmuir ODE solved with `scipy.integrate.solve_ivp`
+- **ODE fitting** — full 1:1 Langmuir ODE propagated with a fast exponential midpoint update
 - **Batch processing** — fit all samples in a file with one call
 - **Non-specific binder detection** — flags samples with reference channel retention
 - **Quality flags** — automatic detection of boundary hits, high residuals, failed fits

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ using a two-stage pipeline: **Direct Kinetics** for fast initial estimates, foll
 
 - **`.cxw` parser** — reads ZIP/XML/HDF5 experiment files directly
 - **Direct Kinetics (DK)** — millisecond-scale linear fit from dR/dt vs R
-- **ODE fitting** — full 1:1 Langmuir ODE propagated with a fast exponential midpoint update
+- **ODE fitting** — full 1:1 Langmuir ODE propagated with a stable fast two-half-step exponential update
 - **Batch processing** — fit all samples in a file with one call
 - **Non-specific binder detection** — flags samples with reference channel retention
 - **Quality flags** — automatic detection of boundary hits, high residuals, failed fits

--- a/docs/fitting_approach.md
+++ b/docs/fitting_approach.md
@@ -256,6 +256,12 @@ Langmuir ODE has an exact exponential solution. This gives a stable,
 second-order update without an adaptive solver inside every residual
 evaluation.
 
+The exponential midpoint propagator is selected by default with
+`fast=True`. For comparison with the original implementation, pass
+`fast=False` to `ode_fitting.fit_sample`, `ode_fitting.ode_fit`, or
+`batch.batch_fit`; this restores the adaptive RK45 solver with the legacy
+tolerances and maximum step size.
+
 **Multi-start protocol** (controlled by `n_starts`, default 3):
 - Start 1: Phase 2 estimates (ka, kd from DK, Rmax)
 - Start 2: DK estimates directly

--- a/docs/fitting_approach.md
+++ b/docs/fitting_approach.md
@@ -250,13 +250,14 @@ $$
 $$
 
 where $R^{sim}$ is obtained by propagating the Langmuir ODE with pulsed
-$c(t)$. Concentration is evaluated at the midpoint of each measured time
-interval and held constant within that interval, for which the scalar
-Langmuir ODE has an exact exponential solution. This gives a stable,
-second-order update without an adaptive solver inside every residual
-evaluation.
+$c(t)$. Each measured time interval is propagated as two half-intervals;
+concentration is evaluated at the midpoint of each half-interval and held
+constant there, for which the scalar Langmuir ODE has an exact exponential
+solution. This retains unconditional stability while improving the accuracy
+of the fast update around changing pulse concentrations, without an adaptive
+solver inside every residual evaluation.
 
-The exponential midpoint propagator is selected by default with
+The two-half-step exponential propagator is selected by default with
 `fast=True`. For comparison with the original implementation, pass
 `fast=False` to `ode_fitting.fit_sample`, `ode_fitting.ode_fit`, or
 `batch.batch_fit`; this restores the adaptive RK45 solver with the legacy

--- a/docs/fitting_approach.md
+++ b/docs/fitting_approach.md
@@ -249,8 +249,12 @@ $$
 \min_{k_a, k_d, R_{max}} \sum_i w_i \cdot \left( R_i^{obs} - R_i^{sim}(k_a, k_d, R_{max}) \right)^2
 $$
 
-where $R^{sim}$ is obtained by integrating the Langmuir ODE with pulsed c(t)
-using `scipy.integrate.solve_ivp` (RK45, rtol=1e-8).
+where $R^{sim}$ is obtained by propagating the Langmuir ODE with pulsed
+$c(t)$. Concentration is evaluated at the midpoint of each measured time
+interval and held constant within that interval, for which the scalar
+Langmuir ODE has an exact exponential solution. This gives a stable,
+second-order update without an adaptive solver inside every residual
+evaluation.
 
 **Multi-start protocol** (controlled by `n_starts`, default 3):
 - Start 1: Phase 2 estimates (ka, kd from DK, Rmax)

--- a/sensofit/__main__.py
+++ b/sensofit/__main__.py
@@ -90,7 +90,9 @@ def _run_mode(filepath, mode, n_starts, output_dir, channels='all', n_parallel_j
     samples = data['samples']
     plot_dir = os.path.join(output_dir, f'{basename}_{mode}_plots')
     paths = save_fit_plots(df, samples, results,
-                            plot_dir, mode=mode, n_parallel_jobs=n_parallel_jobs)
+                            plot_dir, mode=mode,
+                            n_parallel_jobs=n_parallel_jobs,
+                            blanks=data['blanks'])
     n_plots = sum(1 for p in paths if p is not None)
     print(f'  Saved {n_plots} plot(s) → {plot_dir}/')
 

--- a/sensofit/__main__.py
+++ b/sensofit/__main__.py
@@ -66,7 +66,8 @@ def _run_gui():
     from .gui import SensoFitApp
     SensoFitApp().run()
 
-def _run_mode(filepath, mode, n_starts, output_dir, channels='all', n_parallel_jobs=None):
+def _run_mode(filepath, mode, n_starts, output_dir, channels='all',
+              n_parallel_jobs=None, fast=True):
     """Run batch_fit for one file in one mode, save plots and return df."""
     basename = os.path.splitext(os.path.basename(filepath))[0]
 
@@ -75,8 +76,9 @@ def _run_mode(filepath, mode, n_starts, output_dir, channels='all', n_parallel_j
     print(f'Mode: {mode.upper()}')
     print(f'{"=" * 60}')
 
-    df, data, results = batch_fit(filepath, mode=mode,channels=channels,
-                                  progress=True, n_starts=n_starts, n_parallel_jobs=n_parallel_jobs)
+    df, data, results = batch_fit(filepath, mode=mode, channels=channels,
+                                  progress=True, n_starts=n_starts,
+                                  n_parallel_jobs=n_parallel_jobs, fast=fast)
     if df.empty:
         return df
     
@@ -284,6 +286,11 @@ def main(argv=None):
         help='Number of parallel jobs to run. Default: None (not using parallelization).',
     )
     parser.add_argument(
+        '--slow-ode', action='store_false', dest='fast',
+        help='Use the legacy adaptive RK45 ODE solver instead of the fast '
+             'exponential midpoint propagator.',
+    )
+    parser.add_argument(
         '--output', '-o', default='results',
         help='Output directory for CSV and plots. Default: results/',
     )
@@ -307,7 +314,9 @@ def main(argv=None):
     for filepath in cxw_files:
         for mode in modes:
             df = _run_mode(filepath, mode, args.n_starts, args.output,
-                           channels=channels, n_parallel_jobs=args.n_parallel_jobs)
+                           channels=channels,
+                           n_parallel_jobs=args.n_parallel_jobs,
+                           fast=args.fast)
             if df.empty:
                 continue
             all_dfs.append(df)

--- a/sensofit/__main__.py
+++ b/sensofit/__main__.py
@@ -236,7 +236,7 @@ def _run_last_disso_fit(argv):
                 results["koff_ratio_active/ref"].append(koff_active/koff_ref if koff_ref != 0 else np.inf)
                 results["binding_response"].append(bind_response)
             except Exception as e:
-                print(f"Error fitting last dissociation of sample {s['compound']} (cycle {s['index']}, channel {s["channel"]}):\n"
+                print(f"Error fitting last dissociation of sample {s['compound']} (cycle {s['index']}, channel {s['channel']}):\n"
                       f"{e}")
                 continue
         filepath = args.output+"/"+str(os.path.basename(f)).replace(".cxw", "_check.csv")

--- a/sensofit/batch.py
+++ b/sensofit/batch.py
@@ -23,7 +23,7 @@ from .ode_fitting import fit_sample as ode_fit_sample
 
 
 def batch_fit(filepath, mode='dk', channels='all', progress=True,
-              n_starts=3, n_parallel_jobs=None):
+              n_starts=3, n_parallel_jobs=None, fast=True):
     """Fit all samples in a .cxw file (or exported package) and return a DataFrame.
 
     Parameters
@@ -48,6 +48,10 @@ def batch_fit(filepath, mode='dk', channels='all', progress=True,
     n_starts : int
         Number of starting points for ODE multi-start refinement.
         Ignored when mode='dk'.
+    fast : bool
+        Use the exponential midpoint propagator for ODE fitting (default),
+        or the legacy adaptive RK45 solver when false. Ignored when
+        mode='dk'.
 
     Returns
     -------
@@ -79,11 +83,13 @@ def batch_fit(filepath, mode='dk', channels='all', progress=True,
     if n_parallel_jobs:
         all_results = Parallel(n_jobs=n_parallel_jobs, backend="multiprocessing")(
             delayed(_batch_process)(i, t0, n, progress, sample, dmso_cals, blanks, mode,
-                                    fit_func, n_starts) for i, sample in enumerate(samples)
+                                    fit_func, n_starts, fast)
+            for i, sample in enumerate(samples)
         )
     else:
         all_results = [_batch_process(i, t0, n, progress, sample, dmso_cals, blanks, mode,
-                                      fit_func, n_starts) for i, sample in enumerate(samples)]
+                                      fit_func, n_starts, fast)
+                       for i, sample in enumerate(samples)]
 
     results = [r[0] for r in all_results]
     rows = [r[1] for r in all_results]
@@ -102,7 +108,8 @@ def batch_fit(filepath, mode='dk', channels='all', progress=True,
     return df, data, results
 
 
-def _batch_process(i, t0, n, progress, sample, dmso_cals, blanks, mode, fit_func, n_starts):
+def _batch_process(i, t0, n, progress, sample, dmso_cals, blanks, mode, fit_func,
+                   n_starts, fast=True):
     """Process a single sample with error handling and NSB filtering."""
     if progress:
         elapsed = time.time() - t0
@@ -145,6 +152,7 @@ def _batch_process(i, t0, n, progress, sample, dmso_cals, blanks, mode, fit_func
             w = get_weight_from_derivative(sample, blank)
             kwargs["association_weight"] = w
             kwargs['n_starts'] = n_starts
+            kwargs['fast'] = fast
         result = fit_func(sample, dmso, **kwargs)
         row = _extract_row(sample, result, mode)
         row['binding'] = True

--- a/sensofit/models.py
+++ b/sensofit/models.py
@@ -14,7 +14,6 @@ Where:
 
 import numpy as np
 from scipy.interpolate import UnivariateSpline
-from scipy.integrate import solve_ivp
 from scipy.signal import savgol_filter
 from scipy.optimize import curve_fit
 
@@ -924,7 +923,13 @@ def langmuir_ode(t, R, ka, kd, Rmax, c_func):
 
 def simulate_sensorgram(t: np.ndarray, ka: float, kd: float, Rmax: float,
                         c_func, R0: float = 0.0) -> np.ndarray:
-    """Simulate a 1:1 Langmuir sensorgram via ODE integration.
+    """Simulate a 1:1 Langmuir sensorgram with exponential propagation.
+
+    Concentration is evaluated at the midpoint of each measured time
+    interval and treated as constant within that interval.  The scalar
+    Langmuir ODE then has an exact exponential solution.  This is a stable,
+    second-order midpoint approximation for varying ``c(t)`` and avoids the
+    large overhead of an adaptive general-purpose ODE solver during fitting.
 
     Parameters
     ----------
@@ -942,15 +947,28 @@ def simulate_sensorgram(t: np.ndarray, ka: float, kd: float, Rmax: float,
     R : np.ndarray
         Simulated binding response at each time point.
     """
-    sol = solve_ivp(
-        langmuir_ode,
-        t_span=(t[0], t[-1]),
-        y0=[R0],
-        t_eval=t,
-        args=(ka, kd, Rmax, c_func),
-        method='RK45',
-        rtol=1e-8,
-        atol=1e-10,
-        max_step=0.5,
+    t = np.asarray(t, dtype=float)
+    R = np.empty_like(t)
+    if len(t) == 0:
+        return R
+
+    R[0] = R0
+    if len(t) == 1:
+        return R
+
+    dt = np.diff(t)
+    c_mid = np.asarray(c_func(t[:-1] + 0.5 * dt), dtype=float)
+    c_mid = np.broadcast_to(c_mid, dt.shape)
+    rate = ka * c_mid + kd
+    decay = np.exp(-rate * dt)
+    R_eq = np.divide(
+        ka * c_mid * Rmax,
+        rate,
+        out=np.zeros_like(rate),
+        where=rate != 0,
     )
-    return sol.y[0]
+
+    for i in range(1, len(t)):
+        R[i] = R_eq[i - 1] + (R[i - 1] - R_eq[i - 1]) * decay[i - 1]
+
+    return R

--- a/sensofit/models.py
+++ b/sensofit/models.py
@@ -927,10 +927,13 @@ def simulate_sensorgram(t: np.ndarray, ka: float, kd: float, Rmax: float,
                         fast: bool = True) -> np.ndarray:
     """Simulate a 1:1 Langmuir sensorgram.
 
-    When ``fast=True``, concentration is evaluated at the midpoint of each
-    measured time interval and treated as constant within that interval. The
-    scalar Langmuir ODE then has an exact exponential solution. When
-    ``fast=False``, the legacy adaptive RK45 integration path is used.
+    When ``fast=True``, each measured time interval is propagated as two
+    half-intervals.  Concentration is evaluated at the midpoint of each
+    half-interval and held constant there, so each update has an exact
+    exponential solution.  This is a stable, higher-accuracy approximation
+    for varying ``c(t)`` while avoiding the overhead of an adaptive solver
+    inside every residual evaluation.  When ``fast=False``, the legacy
+    adaptive RK45 integration path is used.
 
     Parameters
     ----------
@@ -943,8 +946,8 @@ def simulate_sensorgram(t: np.ndarray, ka: float, kd: float, Rmax: float,
     R0 : float
         Initial response at t[0].
     fast : bool
-        Select the exponential midpoint propagator (default) or the slower
-        adaptive RK45 solver used by the original implementation.
+        Select the two half-step exponential propagator (default) or the
+        slower adaptive RK45 solver used by the original implementation.
 
     Returns
     -------
@@ -976,18 +979,47 @@ def simulate_sensorgram(t: np.ndarray, ka: float, kd: float, Rmax: float,
         return R
 
     dt = np.diff(t)
-    c_mid = np.asarray(c_func(t[:-1] + 0.5 * dt), dtype=float)
-    c_mid = np.broadcast_to(c_mid, dt.shape)
-    rate = ka * c_mid + kd
-    decay = np.exp(-rate * dt)
-    R_eq = np.divide(
-        ka * c_mid * Rmax,
-        rate,
-        out=np.zeros_like(rate),
-        where=rate != 0,
+    half_dt = 0.5 * dt
+    # Two midpoint evaluations per measured interval retain the unconditional
+    # stability of the exponential update, but resolve changes in the pulsed
+    # concentration profile more accurately than one midpoint evaluation.
+    c_eval_t = np.concatenate((
+        t[:-1] + 0.25 * dt,
+        t[:-1] + 0.75 * dt,
+    ))
+    c_eval = np.asarray(c_func(c_eval_t), dtype=float)
+    if c_eval.ndim == 0:
+        c_eval = np.full(c_eval_t.shape, float(c_eval))
+    else:
+        c_eval = np.broadcast_to(c_eval, c_eval_t.shape)
+    c_first = c_eval[:len(dt)]
+    c_second = c_eval[len(dt):]
+
+    # Vectorise the interval coefficients.  Only the state recurrence itself
+    # has to remain serial; evaluating rates, equilibria, and exponentials in
+    # the Python loop would erase much of the fast-path benefit.
+    rate_first = ka * c_first + kd
+    rate_second = ka * c_second + kd
+    decay_first = np.exp(-rate_first * half_dt)
+    decay_second = np.exp(-rate_second * half_dt)
+    equilibrium_first = np.divide(
+        ka * c_first * Rmax,
+        rate_first,
+        out=np.zeros_like(rate_first),
+        where=rate_first != 0,
+    )
+    equilibrium_second = np.divide(
+        ka * c_second * Rmax,
+        rate_second,
+        out=np.zeros_like(rate_second),
+        where=rate_second != 0,
     )
 
     for i in range(1, len(t)):
-        R[i] = R_eq[i - 1] + (R[i - 1] - R_eq[i - 1]) * decay[i - 1]
+        j = i - 1
+        r_half = (equilibrium_first[j]
+                  + (R[i - 1] - equilibrium_first[j]) * decay_first[j])
+        R[i] = (equilibrium_second[j]
+                + (r_half - equilibrium_second[j]) * decay_second[j])
 
     return R

--- a/sensofit/models.py
+++ b/sensofit/models.py
@@ -14,6 +14,7 @@ Where:
 
 import numpy as np
 from scipy.interpolate import UnivariateSpline
+from scipy.integrate import solve_ivp
 from scipy.signal import savgol_filter
 from scipy.optimize import curve_fit
 
@@ -922,14 +923,14 @@ def langmuir_ode(t, R, ka, kd, Rmax, c_func):
 
 
 def simulate_sensorgram(t: np.ndarray, ka: float, kd: float, Rmax: float,
-                        c_func, R0: float = 0.0) -> np.ndarray:
-    """Simulate a 1:1 Langmuir sensorgram with exponential propagation.
+                        c_func, R0: float = 0.0,
+                        fast: bool = True) -> np.ndarray:
+    """Simulate a 1:1 Langmuir sensorgram.
 
-    Concentration is evaluated at the midpoint of each measured time
-    interval and treated as constant within that interval.  The scalar
-    Langmuir ODE then has an exact exponential solution.  This is a stable,
-    second-order midpoint approximation for varying ``c(t)`` and avoids the
-    large overhead of an adaptive general-purpose ODE solver during fitting.
+    When ``fast=True``, concentration is evaluated at the midpoint of each
+    measured time interval and treated as constant within that interval. The
+    scalar Langmuir ODE then has an exact exponential solution. When
+    ``fast=False``, the legacy adaptive RK45 integration path is used.
 
     Parameters
     ----------
@@ -941,6 +942,9 @@ def simulate_sensorgram(t: np.ndarray, ka: float, kd: float, Rmax: float,
         c(t) → concentration (M).
     R0 : float
         Initial response at t[0].
+    fast : bool
+        Select the exponential midpoint propagator (default) or the slower
+        adaptive RK45 solver used by the original implementation.
 
     Returns
     -------
@@ -948,9 +952,24 @@ def simulate_sensorgram(t: np.ndarray, ka: float, kd: float, Rmax: float,
         Simulated binding response at each time point.
     """
     t = np.asarray(t, dtype=float)
-    R = np.empty_like(t)
     if len(t) == 0:
-        return R
+        return np.empty_like(t)
+
+    if not fast:
+        sol = solve_ivp(
+            langmuir_ode,
+            t_span=(t[0], t[-1]),
+            y0=[R0],
+            t_eval=t,
+            args=(ka, kd, Rmax, c_func),
+            method='RK45',
+            rtol=1e-8,
+            atol=1e-10,
+            max_step=0.5,
+        )
+        return sol.y[0]
+
+    R = np.empty_like(t)
 
     R[0] = R0
     if len(t) == 1:

--- a/sensofit/ode_fitting.py
+++ b/sensofit/ode_fitting.py
@@ -34,16 +34,18 @@ def _residuals(params, t_dissoc, signal_dissoc, t0):
     return signal_dissoc - R_model
 
 
-def _residuals_full(params, t, signal, c_func, w):
+def _residuals_full(params, t, signal, c_func, w, fast=True):
     """Full ODE residuals (weighted).
 
     Optimises (ka, kd, Rmax) simultaneously.
     """
     ka, kd, Rmax = params
-    R_sim = simulate_sensorgram(t, ka, kd, Rmax, c_func, R0=0.0)
+    R_sim = simulate_sensorgram(t, ka, kd, Rmax, c_func, R0=0.0,
+                                fast=fast)
     return w * (signal - R_sim)
 
-def _chi2(residuals=None, w=None, n_params=None, R_sim=None, signal=None, params=None, t=None, c_func=None, sqrt=False):
+def _chi2(residuals=None, w=None, n_params=None, R_sim=None, signal=None,
+          params=None, t=None, c_func=None, sqrt=False, fast=True):
     """Calculate Chi2 from ODE residuals.
     
     Chi2 = sum((w * residuals)^2) / (N - n_params)
@@ -52,7 +54,8 @@ def _chi2(residuals=None, w=None, n_params=None, R_sim=None, signal=None, params
         if R_sim is not None:
             residuals = w * (signal - R_sim)
         else:
-            residuals = _residuals_full(params, t, signal, c_func, w)
+            residuals = _residuals_full(params, t, signal, c_func, w,
+                                        fast=fast)
 
     n_points = int((w > 0).sum()) if w is not None else len(residuals)    
     chi2 = np.sum(residuals**2)/(n_points - max(n_params, 1))
@@ -74,7 +77,7 @@ def _solve_R0_Rss(kd, t_dissoc, signal_dissoc, t0):
 
 
 def ode_fit(t, signal, c_func, w, markers, ka0, kd0, Rmax0,
-            n_starts=1, rng_seed=None, skip_s=1.0):
+            n_starts=1, rng_seed=None, skip_s=1.0, fast=True):
     """Fit 1:1 Langmuir parameters via DK-seeded ODE refinement.
 
     Three-phase approach:
@@ -102,6 +105,9 @@ def ode_fit(t, signal, c_func, w, markers, ka0, kd0, Rmax0,
         Random seed for reproducibility.  None (default) = non-reproducible.
     skip_s : float
         Seconds to skip after rinse onset to avoid transport lag.
+    fast : bool
+        Use the exponential midpoint propagator when true (default), or the
+        legacy adaptive RK45 solver when false.
     """
     kd_final = max(kd0, 1e-5)  # kd pinned from DK
 
@@ -150,7 +156,7 @@ def ode_fit(t, signal, c_func, w, markers, ka0, kd0, Rmax0,
         try:
             opt = least_squares(
                 _residuals_full, p0,
-                args=(t, signal, c_func, w),
+                args=(t, signal, c_func, w, fast),
                 bounds=(lb_full, ub_full),
                 method='trf',
                 ftol=1e-6, xtol=1e-6, gtol=1e-6,
@@ -164,7 +170,8 @@ def ode_fit(t, signal, c_func, w, markers, ka0, kd0, Rmax0,
 
     if not fits:
         # Fallback: use derived estimates
-        R_fit = simulate_sensorgram(t, ka_est, kd_final, Rmax_est, c_func, R0=0.0)
+        R_fit = simulate_sensorgram(t, ka_est, kd_final, Rmax_est, c_func,
+                                    R0=0.0, fast=fast)
         fit_mask = np.isfinite(R_fit)
         rmse = get_rmse(signal[fit_mask], R_fit[fit_mask])
         return {
@@ -180,7 +187,7 @@ def ode_fit(t, signal, c_func, w, markers, ka0, kd0, Rmax0,
             'n_points': int((w > 0).sum()),
             'cost': np.nan, 'nfev': 0,
             'n_converged': 0, 'n_starts': n_starts,
-            'success': False, 'message': 'All ODE fits failed',
+            'success': False, 'message': 'All ODE fits failed', 'fast': fast,
         }
 
     # Median aggregation over converged ODE fits
@@ -206,7 +213,7 @@ def ode_fit(t, signal, c_func, w, markers, ka0, kd0, Rmax0,
     
     params = [ka_final_val, kd_final_val, Rmax_final]
     residuals = _residuals_full(
-        params, t, signal, c_func, w)
+        params, t, signal, c_func, w, fast=fast)
     n = int((w > 0).sum())
     dof = max(n - 3, 1)
     sigma2 = np.sum(residuals ** 2) / dof
@@ -222,7 +229,7 @@ def ode_fit(t, signal, c_func, w, markers, ka0, kd0, Rmax0,
         pass
 
     R_fit = simulate_sensorgram(t, ka_final_val, kd_final_val, Rmax_final,
-                                c_func, R0=0.0)
+                                c_func, R0=0.0, fast=fast)
     fit_mask = np.isfinite(R_fit)
     rmse = get_rmse(signal[fit_mask], R_fit[fit_mask])
 
@@ -251,11 +258,13 @@ def ode_fit(t, signal, c_func, w, markers, ka0, kd0, Rmax0,
         'nfev': total_nfev,
         'success': True,
         'message': f'{len(fits)}/{n_starts} ODE starts converged',
+        'fast': fast,
     }
 
 
 def fit_sample(sample, dmso, blank=None, lambda_reg=0.0, initial_estimates='LPF',
-               smoothing_factor=None, neg_ss_correction=False, association_weight=0.0, n_starts=1):
+               smoothing_factor=None, neg_ss_correction=False,
+               association_weight=0.0, n_starts=1, fast=True):
     """Fit a single sample using Direct Kinetics → ODE refinement.
 
     Parameters
@@ -277,6 +286,9 @@ def fit_sample(sample, dmso, blank=None, lambda_reg=0.0, initial_estimates='LPF'
         steady-state response during last dissociation (Rinse → RinseEnd).
     n_starts : int
         Number of starting points for ODE multi-start refinement.
+    fast : bool
+        Use the exponential midpoint propagator when true (default), or the
+        legacy adaptive RK45 solver when false.
 
     Returns
     -------
@@ -342,7 +354,7 @@ def fit_sample(sample, dmso, blank=None, lambda_reg=0.0, initial_estimates='LPF'
     # Step 2: ODE fit on trimmed arrays
     ode = ode_fit(t_fit, sig_fit, c_func_pulsed, w_fit, sample['markers'],
                   ka0=ka_seed, kd0=kd_seed, Rmax0=Rmax_seed,
-                  n_starts=n_starts)
+                  n_starts=n_starts, fast=fast)
 
     # Map R_fit back to full time grid
     R_fit_full = np.full_like(signal, np.nan)
@@ -368,5 +380,6 @@ def fit_sample(sample, dmso, blank=None, lambda_reg=0.0, initial_estimates='LPF'
         ode['signal'] -= min_diss
     ode['dmso_index'] = dmso['index'] if dmso else None
     ode['blank_index'] = blank_index
+    ode['fast'] = fast
 
     return ode

--- a/sensofit/ode_fitting.py
+++ b/sensofit/ode_fitting.py
@@ -106,8 +106,8 @@ def ode_fit(t, signal, c_func, w, markers, ka0, kd0, Rmax0,
     skip_s : float
         Seconds to skip after rinse onset to avoid transport lag.
     fast : bool
-        Use the exponential midpoint propagator when true (default), or the
-        legacy adaptive RK45 solver when false.
+        Use the stable two-half-step exponential propagator when true
+        (default), or the legacy adaptive RK45 solver when false.
     """
     kd_final = max(kd0, 1e-5)  # kd pinned from DK
 
@@ -287,8 +287,8 @@ def fit_sample(sample, dmso, blank=None, lambda_reg=0.0, initial_estimates='LPF'
     n_starts : int
         Number of starting points for ODE multi-start refinement.
     fast : bool
-        Use the exponential midpoint propagator when true (default), or the
-        legacy adaptive RK45 solver when false.
+        Use the stable two-half-step exponential propagator when true
+        (default), or the legacy adaptive RK45 solver when false.
 
     Returns
     -------

--- a/sensofit/plotting.py
+++ b/sensofit/plotting.py
@@ -1,7 +1,9 @@
 """Plotting utilities for SensoFit kinetic fitting results.
 
 Generates individual data-vs-model PNG plots with an information box
-showing compound name, ka, kd, and KD values.
+showing compound name, ka, kd, and KD values.  When the selected blank
+cycle is supplied, the plot also shows the baseline-corrected raw active
+and reference channels alongside the blank used for double referencing.
 """
 
 import os
@@ -10,7 +12,7 @@ from joblib import Parallel, delayed
 import matplotlib.pyplot as plt
 
 
-def plot_fit(result, sample, mode='ode', ax=None, title=None):
+def plot_fit(result, sample, mode='ode', ax=None, title=None, blank=None):
     """Plot data vs model fit for a single sample.
 
     Parameters
@@ -23,18 +25,29 @@ def plot_fit(result, sample, mode='ode', ax=None, title=None):
         If provided, plot on this axes. Otherwise create a new figure.
     title : str or None
         Override title. Default: compound name.
+    blank : dict or None
+        Blank cycle used for double referencing.  When provided, a second
+        panel is added showing baseline-corrected ``raw_active``,
+        ``raw_reference``, and blank ``signal`` traces.
 
     Returns
     -------
     fig : matplotlib.figure.Figure or None
         The figure, or None if *ax* was provided.
     """
-    t = result['t']
-    signal = result['signal']
+    t = np.asarray(result['t'])
+    signal = np.asarray(result['signal'])
 
     fig = None
     if ax is None:
-        fig, ax = plt.subplots(figsize=(8, 5))
+        if blank is not None:
+            fig, axes = plt.subplots(1, 2, sharey=True, figsize=(14, 6))
+            raw_ax, ax = axes
+            _plot_raw_channels(raw_ax, sample, blank)
+        else:
+            # Keep the single-axis behaviour for callers that do not have
+            # the selected blank available (and for minimal result fixtures).
+            fig, ax = plt.subplots(figsize=(8, 5))
 
     # Data trace
     ax.plot(t, signal, color='black', linewidth=0.8, label='Sensorgram')
@@ -107,7 +120,63 @@ def plot_fit(result, sample, mode='ode', ax=None, title=None):
     return fig
 
 
-def save_fit_plots(df, samples, results, output_dir, mode='ode', n_parallel_jobs=None):
+def _baseline_corrected_trace(cycle, value_key):
+    """Return a cycle's time/value trace after baseline subtraction.
+
+    The loader normally supplies ``baseline_duration_s``.  Older exported
+    packages may not, so the Injection marker is used as a conservative
+    fallback.  The returned arrays are truncated to their common length.
+    """
+    time = np.asarray(cycle.get('time', []), dtype=float)
+    values = np.asarray(cycle.get(value_key, []), dtype=float)
+    n = min(time.size, values.size)
+    time = time[:n]
+    values = values[:n]
+    if n == 0:
+        return time, values
+
+    baseline_duration = cycle.get('baseline_duration_s')
+    try:
+        baseline_duration = float(baseline_duration)
+    except (TypeError, ValueError):
+        baseline_duration = np.nan
+    if not np.isfinite(baseline_duration):
+        baseline_duration = cycle.get('markers', {}).get('Injection', time[0])
+
+    baseline_mask = time <= baseline_duration
+    baseline = values[baseline_mask].mean() if baseline_mask.any() else values[0]
+    return time, values - baseline
+
+
+def _plot_raw_channels(ax, sample, blank):
+    """Plot the raw channels and selected blank used by a sample."""
+    t_ref, reference = _baseline_corrected_trace(sample, 'raw_reference')
+    t_active, active = _baseline_corrected_trace(sample, 'raw_active')
+    if t_ref.size:
+        ax.plot(t_ref, reference, color='blue', linewidth=0.8,
+                label='Ref. channel')
+    if t_active.size:
+        ax.plot(t_active, active, color='red', linewidth=0.8,
+                label='Active channel')
+
+    t_blank, blank_signal = _baseline_corrected_trace(blank, 'signal')
+    if t_blank.size:
+        ax.plot(t_blank, blank_signal, color='grey', linewidth=0.75,
+                label='Blank')
+
+    blank_index = blank.get('index')
+    blank_title = 'Raw channels and selected blank'
+    if blank_index is not None:
+        blank_title += f' (cycle {blank_index})'
+    ax.set_title(blank_title, fontsize=11)
+    ax.set_xlabel('Time (s)')
+    ax.set_ylabel('Response (pg/mm²)')
+    ax.legend(loc='upper right', fontsize=9)
+    ax.grid(True, alpha=0.3)
+
+
+def save_fit_plots(df, samples, results, output_dir, mode='ode',
+                   n_parallel_jobs=None, blanks=None):
     """Save individual fit plots as PNGs.
 
     Parameters
@@ -122,6 +191,9 @@ def save_fit_plots(df, samples, results, output_dir, mode='ode', n_parallel_jobs
         Directory to write PNG files into (created if needed).
     mode : str
         Label for the fit mode ('ode' or 'dk').
+    blanks : list[dict] or None
+        Blank cycles from the same experiment.  The blank whose index is
+        stored in each fit result is passed to :func:`plot_fit`.
 
     Returns
     -------
@@ -132,14 +204,18 @@ def save_fit_plots(df, samples, results, output_dir, mode='ode', n_parallel_jobs
     
     if n_parallel_jobs:
         paths = Parallel(n_jobs=n_parallel_jobs, backend="multiprocessing")(
-            delayed(_save_fit_process)(i, row, results, samples, mode, output_dir) for i, row in df.iterrows())
+            delayed(_save_fit_process)(i, row, results, samples, mode,
+                                       output_dir, blanks)
+            for i, row in df.iterrows())
     else:
-        paths = [_save_fit_process(i, row, results, samples, mode, output_dir) for i, row in df.iterrows()]
+        paths = [_save_fit_process(i, row, results, samples, mode,
+                                   output_dir, blanks)
+                 for i, row in df.iterrows()]
 
     return paths
 
 
-def _save_fit_process(i, row, results, samples, mode, output_dir):
+def _save_fit_process(i, row, results, samples, mode, output_dir, blanks=None):
     """Helper for multiprocessing save_fit_plots."""
     idx = row.get('cycle_index')
     ch = row.get('channel', '')
@@ -171,13 +247,44 @@ def _save_fit_process(i, row, results, samples, mode, output_dir):
     if result is None:
         print(f'WARNING! No fit result for sample with RK serie {rk_serie}, cycle number {idx} and channel {ch}, skipping plot.')
         return None
-    fig = plot_fit(result, sample, mode=mode)
+    blank = _find_selected_blank(result, sample, blanks)
+    fig = plot_fit(
+        result,
+        sample,
+        mode=mode,
+        blank=blank,
+    )
     if fig is not None:
         fig.savefig(fpath, dpi=150, bbox_inches='tight')
         plt.close(fig)
         return fpath
     else:
         return None
+
+
+def _find_selected_blank(result, sample, blanks):
+    """Find the blank selected by fitting for the sample being plotted."""
+    if not blanks:
+        return None
+    blank_index = result.get('blank_index')
+    try:
+        blank_index_is_finite = bool(np.isfinite(blank_index))
+    except (TypeError, ValueError):
+        blank_index_is_finite = False
+    if blank_index is None or not blank_index_is_finite:
+        return None
+
+    candidates = [blank for blank in blanks
+                  if blank.get('index') == blank_index]
+    if not candidates:
+        return None
+
+    channel = sample.get('channel')
+    rk_serie_id = sample.get('rk_serie_id')
+    contextual = [blank for blank in candidates
+                  if blank.get('channel') == channel
+                  and blank.get('rk_serie_id') == rk_serie_id]
+    return contextual[0] if contextual else candidates[0]
     
 
 

--- a/sensofit/plotting.py
+++ b/sensofit/plotting.py
@@ -41,11 +41,14 @@ def plot_fit(result, sample, mode='ode', ax=None, title=None):
 
     # Model fit trace
     R_fit = result.get('R_fit')
+    fit_failed = result.get('success') is False
     if R_fit is not None:
         # ODE mode: R_fit has NaN outside fit window
         mask = np.isfinite(R_fit)
-        ax.plot(t[mask], R_fit[mask], color='red' if mode == 'ode' else 'blue', linewidth=1.2,
-                linestyle='--', label='ODE fit' if mode == 'ode' else 'DK fit')
+        fit_color = 'orange' if fit_failed else ('red' if mode == 'ode' else 'blue')
+        fit_label = 'Fallback estimate' if fit_failed else 'Fit'
+        ax.plot(t[mask], R_fit[mask], color=fit_color, linewidth=1.2,
+                linestyle='--', label=fit_label)
     if 'R_smooth' in result:
         # DK mode: plot smoothed signal
         ax.plot(t, result['R_smooth'], color='grey', linewidth=0.8,
@@ -77,7 +80,7 @@ def plot_fit(result, sample, mode='ode', ax=None, title=None):
         f'KD  = {KD:.3e} M',
         f'Rmax = {Rmax:.2f} pg/mm²',
     ]
-    if np.isfinite(rmse):
+    if not fit_failed and np.isfinite(rmse):
         info_lines.append(f'RMSE = {rmse:.3f}')
 
     info_text = '\n'.join(info_lines)
@@ -87,6 +90,14 @@ def plot_fit(result, sample, mode='ode', ax=None, title=None):
             fontfamily='monospace',
             bbox=dict(boxstyle='round,pad=0.4', facecolor='wheat',
                       alpha=0.8))
+
+    if fit_failed:
+        ax.text(0.5, 0.98, 'FIT FAILED',
+                transform=ax.transAxes, fontsize=11, fontweight='bold',
+                color='white', horizontalalignment='center',
+                verticalalignment='top',
+                bbox=dict(boxstyle='round,pad=0.35', facecolor='firebrick',
+                          edgecolor='firebrick', alpha=0.9))
 
     ax.grid(True, alpha=0.3)
 
@@ -133,25 +144,17 @@ def _save_fit_process(i, row, results, samples, mode, output_dir):
     idx = row.get('cycle_index')
     ch = row.get('channel', '')
     rk_serie = row.get('rk_serie_id', '')
-    match_sample = [s for s in samples if s['index'] == idx and s.get('channel', '') == ch and s.get('rk_serie_id', '') == rk_serie]
+    match_sample = [(sample_index, sample) for sample_index, sample in enumerate(samples)
+                    if sample['index'] == idx
+                    and sample.get('channel', '') == ch
+                    and sample.get('rk_serie_id', '') == rk_serie]
     if len(match_sample) > 1:
         print(f'WARNING! Multiple samples with RK serie {rk_serie}, cycle number {idx} and channel {ch}, plotting only the first match.')
     elif len(match_sample) == 0:
         print(f'WARNING! No sample found with RK serie {rk_serie}, cycle number {idx} and channel {ch}, skipping plot.')
         return None
-    sample = match_sample[0]
-    match_result = [r for r in results if r is not None
-                    and r.get('ka') == row.get('ka', np.nan)
-                    and r.get('kd') == row.get('kd', np.nan)
-                    and r.get('KD') == row.get('KD', np.nan)
-                    and r.get('Rmax') == row.get('Rmax', np.nan)
-                    and r.get('rmse') == row.get('rmse', np.nan)]
-    if len(match_result) > 1:
-        print(f'WARNING! Multiple results with same parameters for cycle {idx}, channel {ch}, RK serie {rk_serie}, using only the first match for plotting.')
-    elif len(match_result) == 0:
-        print(f'WARNING! No result found with same parameter values for cycle {idx}, channel {ch}, RK serie {rk_serie}, skipping plot.')
-        return None
-    result = match_result[0]
+    sample_index, sample = match_sample[0]
+    result = results[sample_index] if sample_index < len(results) else None
     compound = sample.get('compound', 'Unknown')
     channel = sample.get('channel', ch)
     idx = sample.get('index', idx)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -146,6 +146,18 @@ class TestSmoothing:
 
 
 class TestSimulation:
+    def test_constant_concentration_matches_exact_solution(self):
+        t = np.array([0.0, 0.1, 0.4, 1.0, 2.0])
+        ka, kd, Rmax, concentration = 1e4, 0.05, 100.0, 2e-5
+        c_func = lambda x: np.full_like(np.asarray(x, dtype=float), concentration)
+
+        result = simulate_sensorgram(t, ka, kd, Rmax, c_func)
+
+        rate = ka * concentration + kd
+        equilibrium = ka * concentration * Rmax / rate
+        expected = equilibrium * (1.0 - np.exp(-rate * t))
+        np.testing.assert_allclose(result, expected, rtol=1e-12, atol=1e-12)
+
     def test_simulate_returns_array(self, dmso, sample):
         c_func, _ = build_concentration_profile(dmso, sample['concentration_M'])
         t = sample['time']

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -146,6 +146,17 @@ class TestSmoothing:
 
 
 class TestSimulation:
+    def test_fast_and_legacy_propagators_agree_for_constant_concentration(self):
+        t = np.linspace(0.0, 20.0, 201)
+        c_func = lambda x: np.full_like(np.asarray(x, dtype=float), 1e-6)
+
+        fast = simulate_sensorgram(t, 1e4, 0.05, 100.0, c_func,
+                                   fast=True)
+        legacy = simulate_sensorgram(t, 1e4, 0.05, 100.0, c_func,
+                                     fast=False)
+
+        np.testing.assert_allclose(fast, legacy, rtol=1e-5, atol=1e-7)
+
     def test_constant_concentration_matches_exact_solution(self):
         t = np.array([0.0, 0.1, 0.4, 1.0, 2.0])
         ka, kd, Rmax, concentration = 1e4, 0.05, 100.0, 2e-5

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -169,6 +169,16 @@ class TestSimulation:
         expected = equilibrium * (1.0 - np.exp(-rate * t))
         np.testing.assert_allclose(result, expected, rtol=1e-12, atol=1e-12)
 
+    def test_fast_propagator_tracks_legacy_for_varying_concentration(self):
+        t = np.linspace(0.0, 20.0, 41)
+        c_func = lambda x: 2e-6 * (1.0 + 0.8 * np.sin(np.asarray(x) / 2.0))
+
+        fast = simulate_sensorgram(t, 2e5, 0.2, 100.0, c_func, fast=True)
+        legacy = simulate_sensorgram(t, 2e5, 0.2, 100.0, c_func,
+                                     fast=False)
+
+        np.testing.assert_allclose(fast, legacy, rtol=5e-4, atol=1e-3)
+
     def test_simulate_returns_array(self, dmso, sample):
         c_func, _ = build_concentration_profile(dmso, sample['concentration_M'])
         t = sample['time']

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 import pytest
 import numpy as np
+import pandas as pd
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
@@ -33,6 +34,43 @@ def dk_result(sample, data):
 
 
 class TestPlotFit:
+    def test_model_trace_is_labelled_fit(self):
+        t = np.array([0.0, 1.0])
+        result = {
+            't': t, 'signal': t, 'R_fit': t,
+            'ka': 1.0, 'kd': 1.0, 'KD': 1.0, 'Rmax': 1.0,
+        }
+        sample = {'compound': 'test', 'concentration_M': 1e-6}
+
+        fig = plot_fit(result, sample)
+        labels = fig.axes[0].get_legend_handles_labels()[1]
+
+        assert 'Fit' in labels
+        assert 'ODE fit' not in labels
+        import matplotlib.pyplot as plt
+        plt.close(fig)
+
+    def test_failed_fit_is_clearly_labelled(self):
+        t = np.array([0.0, 1.0])
+        result = {
+            't': t, 'signal': t, 'R_fit': t,
+            'ka': 1.0, 'kd': 1.0, 'KD': 1.0, 'Rmax': 1.0,
+            'sqrt_chi2': 0.5, 'success': False,
+        }
+        sample = {'compound': 'test', 'concentration_M': 1e-6}
+
+        fig = plot_fit(result, sample)
+        ax = fig.axes[0]
+        labels = ax.get_legend_handles_labels()[1]
+        text = '\n'.join(item.get_text() for item in ax.texts)
+
+        assert 'Fallback estimate' in labels
+        assert 'Fit' not in labels
+        assert 'FIT FAILED' in text
+        assert 'sqrt(chi2)' not in text
+        import matplotlib.pyplot as plt
+        plt.close(fig)
+
     def test_returns_figure(self, dk_result, sample):
         fig = plot_fit(dk_result, sample)
         assert fig is not None
@@ -50,7 +88,12 @@ class TestPlotFit:
 class TestSaveFitPlots:
     def test_saves_pngs(self, dk_result, sample):
         with tempfile.TemporaryDirectory() as tmpdir:
-            paths = save_fit_plots([dk_result], [sample], tmpdir, mode='dk')
+            df = pd.DataFrame([{
+                'cycle_index': sample['index'],
+                'channel': sample.get('channel', ''),
+                'rk_serie_id': sample.get('rk_serie_id', ''),
+            }])
+            paths = save_fit_plots(df, [sample], [dk_result], tmpdir, mode='dk')
             assert len(paths) == 1
             assert paths[0] is not None
             assert os.path.isfile(paths[0])
@@ -58,8 +101,35 @@ class TestSaveFitPlots:
 
     def test_skips_none_results(self, sample):
         with tempfile.TemporaryDirectory() as tmpdir:
-            paths = save_fit_plots([None], [sample], tmpdir)
+            df = pd.DataFrame([{
+                'cycle_index': sample['index'],
+                'channel': sample.get('channel', ''),
+                'rk_serie_id': sample.get('rk_serie_id', ''),
+            }])
+            paths = save_fit_plots(df, [sample], [None], tmpdir)
             assert paths == [None]
+
+    def test_saves_failed_fit_with_nan_residual(self):
+        t = np.array([0.0, 1.0])
+        sample = {
+            'index': 22, 'channel': 'FC2-FC1', 'rk_serie_id': 1,
+            'compound': 'test', 'concentration_M': 1e-6,
+        }
+        result = {
+            't': t, 'signal': t, 'R_fit': t,
+            'ka': 1.0, 'kd': 1.0, 'KD': 1.0, 'Rmax': 1.0,
+            'sigma_residual': np.nan, 'success': False,
+        }
+        df = pd.DataFrame([{
+            'cycle_index': 22, 'channel': 'FC2-FC1', 'rk_serie_id': 1,
+            'sigma_res': np.nan, 'success': False,
+        }])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = save_fit_plots(df, [sample], [result], tmpdir)
+
+            assert paths[0] is not None
+            assert os.path.isfile(paths[0])
 
 
 class TestSanitiseFilename:

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -12,7 +12,12 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 from sensofit.data_loader import load_cxw
 from sensofit.direct_kinetics import fit_sample as dk_fit_sample
 from sensofit.models import select_dmso_cal
-from sensofit.plotting import plot_fit, save_fit_plots, _sanitise_filename
+from sensofit.plotting import (
+    _find_selected_blank,
+    _sanitise_filename,
+    plot_fit,
+    save_fit_plots,
+)
 
 CXW = os.path.join(os.path.dirname(__file__), '..',
                     '20250826_DENV-2 NS2B3 Binding Assay.cxw')
@@ -34,6 +39,52 @@ def dk_result(sample, data):
 
 
 class TestPlotFit:
+    def test_raw_channels_and_selected_blank_are_plotted(self):
+        t = np.arange(4, dtype=float)
+        sample = {
+            'compound': 'test',
+            'concentration_M': 1e-6,
+            'channel': 'FC2-FC1',
+            'baseline_duration_s': 1.0,
+            'time': t,
+            'raw_active': np.array([10.0, 12.0, 20.0, 22.0]),
+            'raw_reference': np.array([5.0, 6.0, 8.0, 9.0]),
+        }
+        blank = {
+            'index': 8,
+            'baseline_duration_s': 1.0,
+            'time': t,
+            'signal': np.array([1.0, 2.0, 3.0, 4.0]),
+        }
+        result = {
+            't': t,
+            'signal': np.array([0.0, 1.0, 2.0, 3.0]),
+            'R_fit': np.array([0.0, 1.0, 2.0, 3.0]),
+            'ka': 1.0,
+            'kd': 1.0,
+            'KD': 1.0,
+            'Rmax': 1.0,
+        }
+
+        fig = plot_fit(result, sample, blank=blank)
+        assert len(fig.axes) == 2
+        labels = fig.axes[0].get_legend_handles_labels()[1]
+        assert labels == ['Ref. channel', 'Active channel', 'Blank']
+        np.testing.assert_allclose(fig.axes[0].lines[0].get_ydata(), [-0.5, 0.5, 2.5, 3.5])
+        np.testing.assert_allclose(fig.axes[0].lines[1].get_ydata(), [-1.0, 1.0, 9.0, 11.0])
+        np.testing.assert_allclose(fig.axes[0].lines[2].get_ydata(), [-0.5, 0.5, 1.5, 2.5])
+
+        import matplotlib.pyplot as plt
+        plt.close(fig)
+
+    def test_selected_blank_is_matched_to_sample_context(self):
+        sample = {'channel': 'FC2-FC1', 'rk_serie_id': 1}
+        result = {'blank_index': 8}
+        wrong_channel = {'index': 8, 'channel': 'FC3-FC1', 'rk_serie_id': 1}
+        selected = {'index': 8, 'channel': 'FC2-FC1', 'rk_serie_id': 1}
+
+        assert _find_selected_blank(result, sample, [wrong_channel, selected]) is selected
+
     def test_model_trace_is_labelled_fit(self):
         t = np.array([0.0, 1.0])
         result = {


### PR DESCRIPTION
This PR adds the fast two-half-step exponential Langmuir propagator, retains the legacy adaptive RK45 solver behind fast=False, enhances fit plots with raw active/reference/blank traces, improves failed-fit labelling, and includes related tests and documentation. The data-characterisation process is intentionally excluded.