### PR TITLE
Add interpretable pre-fit affinity trace score

### DIFF
--- a/data/experimentalist_benchmark/affinity_concentration_overrides.csv
+++ b/data/experimentalist_benchmark/affinity_concentration_overrides.csv
@@ -1,0 +1,2 @@
+source_file,cycle_index,concentration_M
+20260323_EV712A_Binding_assay.cxw,205,2.5e-6

--- a/docs/affinity_area_prior.md
+++ b/docs/affinity_area_prior.md
@@ -1,0 +1,147 @@
+# Pre-fit affinity area prior
+
+SensoFit can characterise a trace before kinetic fitting using a cheap summary
+of the raw active and reference channels. The result contains an ordinal score,
+and the component diagnostics needed to audit it. It deliberately does not
+assign a binding class or modify the kinetic fit.
+
+The screen baseline-corrects both channels using the 20–2 second
+pre-injection window, then records time-averaged areas (AUC divided by window
+duration) during association (injection +0.5 seconds to rinse −0.5 seconds),
+late association (approximately the final 10 seconds), early dissociation
+(1–10 seconds after rinse), and the 30–60 second dissociation tail. The final
+five seconds before `RinseEnd` are excluded to avoid marker-boundary artefacts.
+
+The current score uses six interpretable, monotonic terms:
+
+```text
+association_selectivity =
+    clipped positive association active-minus-reference mean
+    / association response scale
+
+retention_ratio =
+    clipped positive early-dissociation active-minus-reference mean
+    / late-association active-minus-reference mean
+
+score = 2.00
+        + 0.2 * -log10(concentration_M)
+        + 1.0 * log10(association_selectivity)
+        + (1/3) * log10(retention_ratio)
+        + 0.15 * log10(tail_survival_ratio)
+        + positive_early_decay_delta_BIC
+          / (positive_early_decay_delta_BIC + 100)
+        + 0.5 * sqrt(retained_tail_fraction)
+
+retained_tail_fraction = retention_ratio * tail_survival_ratio
+```
+
+The association response scale is the sum of the absolute active and reference
+association means over the injection +0.5 second to rinse −0.5 second window,
+with floors based on baseline noise and one response unit. Selectivity
+approximates specific occupancy relative to the common-mode response.
+Retention divides the 1–10 second post-rinse mean by the mean over the final
+approximately 10 seconds of association (rinse −10 to −0.5 seconds), adding
+early off-rate information. The concentration term uses the injected analyte
+concentration recorded for the whole trace rather than a timed response.
+
+`tail_survival_ratio` is the response retained at 30–60 seconds after rinse
+relative to the response retained at 1–10 seconds. This ratio cancels the
+association response scale and therefore targets decay shape rather than
+binding amplitude. When both dissociation windows are at the noise floor, the
+term is neutral.
+
+The early-decay term compares two small local models from 0.15–10 seconds
+after rinse. Both contain a scaled copy of the reference trace, an intercept,
+and linear drift. The alternative adds a positive exponential decay. `koff`
+is selected from a fixed one-dimensional grid and the other parameters use
+linear least squares; this is a local shape comparison rather than a full
+kinetic fit. The BIC difference includes a two-parameter penalty for amplitude
+and `koff`. Only positive evidence contributes to the score. Because BIC
+establishes that an exponential component is convincing rather than that it
+is slow, its contribution is bounded as `B / (B + 100)`, where
+`B = max(early_decay_delta_BIC, 0)`. This gives half credit at a positive
+delta-BIC of 100 and approaches, but never reaches, a maximum contribution of
+one.
+
+The retained-tail persistence term uses
+`retention_ratio * tail_survival_ratio`, which simplifies to the
+drift-corrected 30–60 second response divided by the late-association response.
+Its contribution is `0.5 * sqrt(retained_tail_fraction)`. This provides direct
+positive evidence when a substantial absolute fraction of the association
+response remains well into dissociation, while the square root prevents the
+strongest tails from dominating the score. Using the absolute retained
+fraction also avoids rewarding response-floor traces whose tail-survival ratio
+is defined as neutral.
+
+The 30–60 second mean receives a narrowly gated differential-drift correction
+when the active channel finishes below the reference channel. A straight drift
+line is anchored at injection and estimated from the final three seconds, but
+it is applied only to the tail mean—not to association or early retention.
+Correction requires association selectivity of at least `0.10` and early
+retention of at least `0.25`.
+
+The endpoint condition is smooth rather than binary. If `d` is the amount by
+which the endpoint lies below its baseline and `sigma` is baseline noise, the
+applied fraction of the inferred drift is
+
+```text
+drift_weight = d^2 / (d^2 + (3 * sigma)^2)
+```
+
+Positive endpoints receive zero correction; increasingly convincing negative
+drift approaches full correction continuously. The raw and corrected tail
+means, endpoint, applied slope, drift weight, and early-decay diagnostics are
+all exported.
+
+The original coefficients were a non-negative least-squares fit to ordered targets
+(`no_binding=0`, `weak=1`, `medium=2`, `tight=3`). Requiring non-negative
+slopes fixes each feature's physical direction. The first three slopes are
+rounded to exactly `0.2`, `1`, and `1/3`; the tail-survival coefficient is
+`0.15`. The bounded BIC term has unit maximum contribution, and the retained-
+tail persistence coefficient is `0.5`. No compound or assay identifiers are
+included.
+
+The intercept is fixed at the round value `2.00`. Classification thresholds
+are not part of the estimator because the score should be validated on an
+independent assay panel before cutoffs are treated as transferable.
+
+Call the estimator directly with a sample returned by the SensoFit data
+loader:
+
+```python
+from sensofit.affinity_prior import estimate_affinity_area_prior
+
+prior = estimate_affinity_area_prior(sample)
+print(prior.score)
+print(prior.association_selectivity, prior.retention_ratio)
+```
+
+If the raw channels, markers, baseline, or positive concentration are
+unavailable, the estimator raises `ValueError` with the failed requirement.
+
+To reproduce the experimentalist-label diagnostic:
+
+```bash
+python -m scripts.benchmark_affinity_area_prior \
+  --data-dir data \
+  --output runs/affinity_area_prior.csv
+```
+
+The optional `affinity_concentration_overrides.csv` file makes
+experimentalist-supplied corrections to missing or incorrect source metadata
+explicit without changing the shared benchmark annotation schema. The current
+override uses `2.5e-6` M for cycle 205 of
+`20260323_EV712A_Binding_assay.cxw`.
+
+On the 48 annotated affinity-regime traces, all traces were scored and the
+in-sample Spearman correlation with ordered labels (`no_binding`, `weak`,
+`medium`, `tight`) was 0.924. For comparison with those labels, the benchmark
+script applies reporting cutoffs of 0.80, 2.00, and 2.97. These classify 45/48
+traces correctly (93.8%): 4/4 non-binders, 13/14 weak, 20/21 medium, and 8/9
+tight.
+Recalibrating the thresholds under leave-one-compound-out validation classified
+44/48 traces correctly (91.7%), showing that one of the two apparent gains is
+threshold-sensitive. Refitting the monotonic coefficient model under the same
+compound-held-out scheme gave Spearman 0.895 and ordinal mean absolute error
+0.288. Medium and tight traces still overlap, so the cutoffs remain a benchmark
+diagnostic rather than part of the estimator API.

--- a/scripts/benchmark_affinity_area_prior.py
+++ b/scripts/benchmark_affinity_area_prior.py
@@ -1,0 +1,179 @@
+"""Evaluate the pre-fit area score against experimentalist affinity labels."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from scipy.optimize import lsq_linear
+
+from sensofit.affinity_prior import estimate_affinity_area_prior
+from sensofit.data_loader import load_cxw
+
+
+ORDINAL_LABEL = {"no_binding": 0, "weak": 1, "medium": 2, "tight": 3}
+# Reporting cutoffs for comparison with the annotated benchmark only.
+SCORE_BINS = [-np.inf, 0.80, 2.00, 2.97, np.inf]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--annotations",
+        default="data/experimentalist_benchmark/affinity_regime.csv",
+    )
+    parser.add_argument(
+        "--concentration-overrides",
+        default=(
+            "data/experimentalist_benchmark/"
+            "affinity_concentration_overrides.csv"
+        ),
+        help=(
+            "Optional CSV with source_file, cycle_index and concentration_M "
+            "for corrections to missing or incorrect source metadata."
+        ),
+    )
+    parser.add_argument("--data-dir", default="data")
+    parser.add_argument("--output", default=None)
+    args = parser.parse_args()
+
+    annotations = pd.read_csv(args.annotations)
+    concentration_overrides = {}
+    overrides_path = Path(args.concentration_overrides)
+    if overrides_path.exists():
+        overrides = pd.read_csv(overrides_path)
+        expected = ["source_file", "cycle_index", "concentration_M"]
+        if list(overrides.columns) != expected:
+            raise ValueError(
+                f"{overrides_path} columns must be exactly {expected}"
+            )
+        concentration_overrides = {
+            (Path(row.source_file).name, int(row.cycle_index)):
+                float(row.concentration_M)
+            for row in overrides.itertuples(index=False)
+        }
+    data_dir = Path(args.data_dir)
+    experiments = {}
+    rows = []
+    for annotation in annotations.itertuples(index=False):
+        source = Path(annotation.source_file).name
+        if source not in experiments:
+            matches = list(data_dir.rglob(source))
+            if not matches:
+                raise FileNotFoundError(
+                    f"could not find {source} under {data_dir}"
+                )
+            selected = min(matches, key=lambda path: len(path.parts))
+            experiments[source] = load_cxw(selected, channels="all")
+        sample = next(
+            sample for sample in experiments[source]["samples"]
+            if int(sample["index"]) == int(annotation.cycle_index)
+            and str(sample.get("rk_serie_id")) == str(annotation.rk_serie_id)
+            and sample["channel"] == annotation.channel
+        )
+        override = concentration_overrides.get(
+            (source, int(annotation.cycle_index))
+        )
+        if override is not None:
+            sample = {
+                **sample,
+                "concentration_M": float(override),
+                "concentration_overridden": True,
+            }
+        prior = estimate_affinity_area_prior(sample)
+        rows.append({
+            "source_file": source,
+            "rk_serie_id": annotation.rk_serie_id,
+            "cycle_index": annotation.cycle_index,
+            "channel": annotation.channel,
+            "compound": annotation.compound,
+            "experimentalist_label": annotation.experimentalist_label,
+            **prior.as_dict(),
+        })
+
+    result = pd.DataFrame(rows)
+    result["predicted_regime"] = pd.cut(
+        result["score"],
+        bins=SCORE_BINS,
+        labels=list(ORDINAL_LABEL),
+        right=False,
+    )
+    result["experimentalist_ordinal"] = result[
+        "experimentalist_label"].map(ORDINAL_LABEL)
+    rho = result["score"].corr(
+        result["experimentalist_ordinal"], method="spearman")
+    print(f"scored: {len(result)}")
+    print(f"Spearman score vs affinity ordinal: {rho:.3f}")
+    design = np.column_stack([
+        np.ones(len(result)),
+        -np.log10(result["concentration_M"].to_numpy()),
+        np.log10(result["association_selectivity"].to_numpy()),
+        np.log10(result["retention_ratio"].to_numpy()),
+        np.log10(result["tail_survival_ratio"].to_numpy()),
+        (
+            np.maximum(result["early_decay_delta_bic"].to_numpy(), 0.0)
+            / (
+                np.maximum(
+                    result["early_decay_delta_bic"].to_numpy(), 0.0,
+                )
+                + 100.0
+            )
+        ),
+        np.sqrt(result["retained_tail_fraction"].to_numpy()),
+    ])
+    target = result["experimentalist_ordinal"].to_numpy(dtype=float)
+    coefficient_fit = lsq_linear(
+        design,
+        target,
+        bounds=(
+            [-np.inf, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [np.inf, np.inf, np.inf, np.inf, np.inf, np.inf, np.inf],
+        ),
+    )
+    print(
+        "Monotonic ordinal coefficients "
+        "(intercept, concentration, selectivity, retention, tail survival, "
+        "bounded early decay, retained-tail persistence): "
+        + ", ".join(f"{value:.3f}" for value in coefficient_fit.x)
+    )
+    grouped_prediction = np.full(len(result), np.nan)
+    compounds = result["compound"].fillna("").astype(str).to_numpy()
+    for compound in np.unique(compounds):
+        test = compounds == compound
+        train = ~test
+        fold_fit = lsq_linear(
+            design[train],
+            target[train],
+            bounds=(
+                [-np.inf, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [np.inf, np.inf, np.inf, np.inf, np.inf, np.inf, np.inf],
+            ),
+        )
+        grouped_prediction[test] = design[test] @ fold_fit.x
+    grouped_rho = pd.Series(grouped_prediction).corr(
+        pd.Series(target), method="spearman")
+    grouped_mae = float(np.mean(np.abs(grouped_prediction - target)))
+    print(
+        "Leave-one-compound-out: "
+        f"Spearman={grouped_rho:.3f}, ordinal MAE={grouped_mae:.3f}"
+    )
+    print(
+        result.groupby("experimentalist_label")["score"]
+        .agg(["count", "min", "median", "max"])
+        .reindex(ORDINAL_LABEL)
+        .round(3)
+        .to_string()
+    )
+    print("\nPredicted regime by experimentalist label:")
+    print(pd.crosstab(
+        result["experimentalist_label"],
+        result["predicted_regime"],
+    ).reindex(index=ORDINAL_LABEL, columns=ORDINAL_LABEL, fill_value=0))
+    if args.output:
+        result.to_csv(args.output, index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/sensofit/affinity_prior.py
+++ b/sensofit/affinity_prior.py
@@ -1,0 +1,384 @@
+"""Interpretable pre-fit affinity characterisation for GCI sensorgrams.
+
+The score combines analyte concentration with baseline-corrected association,
+early-dissociation and retained-tail summaries.  A bounded local BIC comparison
+adds evidence that a reference-adjusted exponential decay is present.  Every
+component is returned as a diagnostic rather than hidden inside a classifier.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+import numpy as np
+
+
+# The original concentration, selectivity and retention coefficients were a
+# non-negative least-squares fit to ordered experimentalist labels, then
+# rounded to simple values.  Tail survival, bounded BIC and persistence were
+# added as physically directed refinements.  See the benchmark script.
+ORDINAL_INTERCEPT = 2.0
+CONCENTRATION_COEFFICIENT = 0.2
+SELECTIVITY_COEFFICIENT = 1.0
+RETENTION_COEFFICIENT = 1.0 / 3.0
+TAIL_SURVIVAL_COEFFICIENT = 0.15
+EARLY_DECAY_BIC_HALF_SATURATION = 100.0
+PERSISTENCE_COEFFICIENT = 0.5
+
+# A negative active-minus-reference endpoint is treated as differential
+# channel drift only when the earlier trace already contains independent
+# binder-like evidence.  This prevents an endpoint correction from turning
+# noise in weak/non-binding traces into apparent late retention.
+TAIL_DRIFT_MIN_SELECTIVITY = 0.10
+TAIL_DRIFT_MIN_RETENTION = 0.25
+TAIL_DRIFT_SHRINKAGE_SNR = 3.0
+END_GUARD_SECONDS = 5.0
+
+
+@dataclass(frozen=True)
+class AffinityAreaPrior:
+    """Affinity score and its component diagnostics."""
+
+    score: float
+    concentration_M: float
+    baseline_noise: float
+    association_active_mean: float
+    association_reference_mean: float
+    association_between_mean: float
+    late_association_between_mean: float
+    early_dissociation_active_mean: float
+    early_dissociation_reference_mean: float
+    early_dissociation_between_mean: float
+    raw_tail_dissociation_between_mean: float
+    tail_dissociation_between_mean: float
+    late_dissociation_between_mean: float
+    tail_drift_corrected: bool
+    tail_drift_weight: float
+    tail_drift_slope: float
+    tail_endpoint_between: float
+    early_decay_delta_bic: float
+    early_decay_amplitude: float
+    early_decay_koff: float
+    early_decay_reference_scale: float
+    response_scale: float
+    early_dissociation_fraction: float
+    association_selectivity: float
+    retention_ratio: float
+    tail_survival_ratio: float
+    concentration_evidence: float
+    selectivity_evidence: float
+    retention_evidence: float
+    tail_survival_evidence: float
+    early_decay_evidence: float
+    retained_tail_fraction: float
+    persistence_evidence: float
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+def _window_mean(t, values, start, stop):
+    mask = (
+        np.isfinite(t) & np.isfinite(values)
+        & (t >= float(start)) & (t <= float(stop))
+    )
+    if mask.sum() < 3:
+        return np.nan
+    selected_t = t[mask]
+    duration = float(selected_t[-1] - selected_t[0])
+    if duration <= 0:
+        return np.nan
+    return float(np.trapezoid(values[mask], selected_t) / duration)
+
+
+def _early_decay_reference_evidence(
+    t, active, reference, rinse,
+):
+    """Compare reference-template models over the first 10 s after rinse.
+
+    The alternative adds a positive exponential to a scaled reference trace,
+    intercept, and linear drift.  This is a local shape comparison rather than
+    a full kinetic fit: koff is selected from a fixed one-dimensional grid and
+    all remaining parameters are ordinary linear least squares.
+    """
+    mask = (
+        np.isfinite(t) & np.isfinite(active) & np.isfinite(reference)
+        & (t >= rinse + 0.15) & (t <= rinse + 10.0)
+    )
+    if mask.sum() < 12:
+        return np.nan, np.nan, np.nan, np.nan
+    dt = t[mask] - rinse
+    yy = active[mask]
+    rr = reference[mask]
+    null_design = np.column_stack([rr, np.ones(len(dt)), dt])
+    null_parameters, *_ = np.linalg.lstsq(
+        null_design, yy, rcond=None)
+    null_residual = yy - null_design @ null_parameters
+    null_rss = max(float(np.sum(null_residual ** 2)), 1e-12)
+
+    best = None
+    for koff in np.geomspace(0.01, 5.0, 160):
+        design = np.column_stack([
+            rr, np.exp(-koff * dt), np.ones(len(dt)), dt,
+        ])
+        parameters, *_ = np.linalg.lstsq(design, yy, rcond=None)
+        amplitude = float(parameters[1])
+        if amplitude < 0:
+            continue
+        residual = yy - design @ parameters
+        rss = max(float(np.sum(residual ** 2)), 1e-12)
+        if best is None or rss < best[0]:
+            best = (
+                rss, float(amplitude), float(koff),
+                float(parameters[0]),
+            )
+    if best is None:
+        return 0.0, 0.0, np.nan, float(null_parameters[0])
+
+    # Relative to the null, the alternative adds amplitude and koff.  The
+    # two-parameter BIC penalty prevents small improvements from becoming
+    # positive evidence merely because the koff grid was searched.
+    delta_bic = float(
+        len(dt) * np.log(null_rss / best[0])
+        - 2.0 * np.log(len(dt))
+    )
+    return delta_bic, best[1], best[2], best[3]
+
+
+def estimate_affinity_area_prior(sample) -> AffinityAreaPrior:
+    """Characterise a trace before kinetic fitting.
+
+    The monotonic score combines concentration, association selectivity,
+    early retention, tail survival, bounded decay-model evidence and absolute
+    retained-tail persistence.
+    """
+    try:
+        concentration = float(sample["concentration_M"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(
+            "sample must contain a numeric concentration_M"
+        ) from error
+    if not np.isfinite(concentration) or concentration <= 0:
+        raise ValueError("concentration_M must be finite and positive")
+
+    try:
+        t = np.asarray(sample["time"], dtype=float)
+        active = np.asarray(sample["raw_active"], dtype=float)
+        reference = np.asarray(sample["raw_reference"], dtype=float)
+        markers = sample["markers"]
+        injection = float(markers["Injection"])
+        rinse = float(markers["Rinse"])
+        rinse_end = float(markers["RinseEnd"])
+    except (KeyError, TypeError, ValueError):
+        raise ValueError(
+            "sample must contain raw_active, raw_reference, time, and markers"
+        ) from None
+    if (
+        t.ndim != 1 or active.shape != t.shape or reference.shape != t.shape
+        or not injection < rinse < rinse_end
+    ):
+        raise ValueError("raw channels or marker times are invalid")
+
+    baseline = (
+        np.isfinite(t) & np.isfinite(active) & np.isfinite(reference)
+        & (t >= max(float(t[0]), injection - 20.0))
+        & (t <= injection - 2.0)
+    )
+    if baseline.sum() < 5:
+        raise ValueError("trace has insufficient pre-injection baseline")
+    active = active - float(np.median(active[baseline]))
+    reference = reference - float(np.median(reference[baseline]))
+    between = active - reference
+    baseline_center = float(np.median(between[baseline]))
+    noise = float(
+        1.4826 * np.median(np.abs(between[baseline] - baseline_center))
+    )
+
+    association_start = injection + 0.5
+    association_stop = rinse - 0.5
+    analysis_end = rinse_end - END_GUARD_SECONDS
+    early_stop = min(rinse + 10.0, analysis_end)
+    late_start = max(rinse + 1.0, rinse_end - 20.0)
+    windows = {
+        "association_active_mean": _window_mean(
+            t, active, association_start, association_stop),
+        "association_reference_mean": _window_mean(
+            t, reference, association_start, association_stop),
+        "association_between_mean": _window_mean(
+            t, between, association_start, association_stop),
+        "late_association_between_mean": _window_mean(
+            t, between, max(association_start, rinse - 10.0),
+            association_stop),
+        "early_dissociation_active_mean": _window_mean(
+            t, active, rinse + 1.0, early_stop),
+        "early_dissociation_reference_mean": _window_mean(
+            t, reference, rinse + 1.0, early_stop),
+        "early_dissociation_between_mean": _window_mean(
+            t, between, rinse + 1.0, early_stop),
+        "raw_tail_dissociation_between_mean": _window_mean(
+            t, between, rinse + 30.0, min(rinse + 60.0, analysis_end)),
+        "late_dissociation_between_mean": _window_mean(
+            t, between, late_start, analysis_end),
+    }
+    if not np.isfinite(list(windows.values())).all():
+        raise ValueError("trace has insufficient data in a scoring window")
+
+    response_scale = max(
+        abs(windows["association_active_mean"])
+        + abs(windows["association_reference_mean"]),
+        3.0 * noise,
+        1.0,
+    )
+    selectivity = float(np.clip(
+        max(windows["association_between_mean"], 0.0) / response_scale,
+        1e-3,
+        0.999,
+    ))
+    retention = float(np.clip(
+        max(windows["early_dissociation_between_mean"], 0.0)
+        / max(
+            windows["late_association_between_mean"],
+            noise,
+            1e-6,
+        ),
+        1e-3,
+        1.5,
+    ))
+
+    # Correct only the 30--60 s tail for a negative differential-channel
+    # drift.  The linear drift is anchored at injection and estimated from
+    # the final 3 s; association and early-retention evidence are left
+    # untouched.  Requiring both of those independent pieces of evidence
+    # makes this a conditional measurement correction rather than a binder
+    # classifier based on the endpoint.
+    # Use the final 3 s before the end guard as the endpoint.  A longer window
+    # can be centred inside the 30--60 s tail itself and consequently subtract
+    # away genuine curvature/retention that the correction should preserve.
+    endpoint_start = max(rinse + 1.0, analysis_end - 3.0)
+    endpoint = _window_mean(t, between, endpoint_start, analysis_end)
+    endpoint_time = 0.5 * (endpoint_start + analysis_end)
+    eligible_tail_drift = bool(
+        selectivity >= TAIL_DRIFT_MIN_SELECTIVITY
+        and retention >= TAIL_DRIFT_MIN_RETENTION
+        and np.isfinite(endpoint)
+        and endpoint < baseline_center
+        and endpoint_time > injection
+    )
+    drift_depth = max(baseline_center - endpoint, 0.0)
+    shrinkage_scale = TAIL_DRIFT_SHRINKAGE_SNR * max(noise, 1e-6)
+    tail_drift_weight = (
+        float(
+            drift_depth ** 2
+            / (drift_depth ** 2 + shrinkage_scale ** 2)
+        )
+        if eligible_tail_drift else 0.0
+    )
+    correct_tail_drift = tail_drift_weight > 0.0
+    tail_drift_slope = 0.0
+    if correct_tail_drift:
+        tail_drift_slope = float(
+            tail_drift_weight * (endpoint - baseline_center)
+            / (endpoint_time - injection)
+        )
+        drift = tail_drift_slope * np.clip(t - injection, 0.0, None)
+        tail_between = between - drift
+        tail_mean = _window_mean(
+            t, tail_between, rinse + 30.0,
+            min(rinse + 60.0, analysis_end),
+        )
+    else:
+        tail_mean = windows["raw_tail_dissociation_between_mean"]
+    windows["tail_dissociation_between_mean"] = tail_mean
+
+    tail_retention = float(np.clip(
+        max(windows["tail_dissociation_between_mean"], 0.0)
+        / max(
+            windows["late_association_between_mean"],
+            noise,
+            1e-6,
+        ),
+        1e-3,
+        1.5,
+    ))
+    # This ratio isolates decay shape: association amplitude and selectivity
+    # cancel because both numerator and denominator share the same scale.
+    # If both windows are at the response floor, survival is neutral rather
+    # than spuriously perfect evidence for tight binding.
+    tail_survival = (
+        1.0
+        if retention <= 1.001e-3 and tail_retention <= 1.001e-3
+        else float(np.clip(tail_retention / retention, 1e-3, 1.0))
+    )
+    fraction = max(
+        windows["early_dissociation_between_mean"] / response_scale, 1e-3,
+    )
+    concentration_evidence = float(
+        CONCENTRATION_COEFFICIENT * -np.log10(concentration))
+    selectivity_evidence = float(
+        SELECTIVITY_COEFFICIENT * np.log10(selectivity))
+    retention_evidence = float(
+        RETENTION_COEFFICIENT * np.log10(retention))
+    tail_survival_evidence = float(
+        TAIL_SURVIVAL_COEFFICIENT * np.log10(tail_survival))
+    (
+        early_decay_delta_bic,
+        early_decay_amplitude,
+        early_decay_koff,
+        early_decay_reference_scale,
+    ) = _early_decay_reference_evidence(
+        t, active, reference, rinse,
+    )
+    # BIC establishes whether an exponential component is credible, not how
+    # tight the binder is.  Convert it to bounded evidence: half credit at a
+    # positive delta-BIC of 100 and an asymptotic maximum of one.
+    positive_delta_bic = max(early_decay_delta_bic, 0.0)
+    early_decay_evidence = float(
+        positive_delta_bic
+        / (positive_delta_bic + EARLY_DECAY_BIC_HALF_SATURATION)
+        if np.isfinite(early_decay_delta_bic) else 0.0
+    )
+    # Retention times tail survival is the absolute fraction of the late
+    # association response remaining at 30--60 s.  Its square root supplies a
+    # smooth positive persistence contribution without allowing the strongest
+    # tails to dominate the score.
+    retained_tail_fraction = float(np.clip(
+        retention * tail_survival, 1e-6, 1.5,
+    ))
+    persistence_evidence = float(
+        PERSISTENCE_COEFFICIENT * np.sqrt(retained_tail_fraction)
+    )
+    score = float(
+        ORDINAL_INTERCEPT
+        + concentration_evidence
+        + selectivity_evidence
+        + retention_evidence
+        + tail_survival_evidence
+        + early_decay_evidence
+        + persistence_evidence
+    )
+    return AffinityAreaPrior(
+        score=score,
+        concentration_M=concentration,
+        baseline_noise=noise,
+        tail_drift_corrected=correct_tail_drift,
+        tail_drift_weight=tail_drift_weight,
+        tail_drift_slope=tail_drift_slope,
+        tail_endpoint_between=endpoint,
+        early_decay_delta_bic=early_decay_delta_bic,
+        early_decay_amplitude=early_decay_amplitude,
+        early_decay_koff=early_decay_koff,
+        early_decay_reference_scale=early_decay_reference_scale,
+        response_scale=response_scale,
+        early_dissociation_fraction=fraction,
+        association_selectivity=selectivity,
+        retention_ratio=retention,
+        tail_survival_ratio=tail_survival,
+        concentration_evidence=concentration_evidence,
+        selectivity_evidence=selectivity_evidence,
+        retention_evidence=retention_evidence,
+        tail_survival_evidence=tail_survival_evidence,
+        early_decay_evidence=early_decay_evidence,
+        retained_tail_fraction=retained_tail_fraction,
+        persistence_evidence=persistence_evidence,
+        **windows,
+    )


### PR DESCRIPTION
## Summary

- add a standalone, auditable pre-fit affinity characterisation score
- combine concentration, association selectivity, early retention, drift-corrected tail survival, bounded early-decay BIC evidence, and retained-tail persistence
- return the score and its components without assigning a regime or changing fitting or CLI behaviour

## Benchmark

On the 48 annotated examples in the experimentalist benchmark:

- 48/48 traces produced usable scores
- Spearman correlation with ordered affinity labels: 0.924
- classification accuracy: 45/48 (93.8%)
- per-label accuracy: no binding 4/4, weak 13/14, medium 20/21, tight 8/9

## Validation

- `pytest -q tests/test_benchmark.py` — 7 passed
- `python -m compileall -q sensofit scripts` — passed
- all 48 annotated examples scored successfully

## Scope

This PR reports a pre-fit score and diagnostics only. Thresholds for classification are separate from the score.